### PR TITLE
Extended CSV Output

### DIFF
--- a/src/gitsweep/tests/test_cli.py
+++ b/src/gitsweep/tests/test_cli.py
@@ -78,6 +78,27 @@ class TestHelpMenu(CommandTestCase):
 
             To delete them, run again with `git-sweep cleanup`
             ''', stdout)
+    
+    def test_will_preview_csv(self):
+        """
+        Will preview the proposed deletes in CSV format
+        """
+        for i in range(1, 6):
+            self.command('git checkout -b branch{0}'.format(i))
+            self.make_commit()
+            self.command('git checkout master')
+            self.make_commit()
+            self.command('git merge branch{0}'.format(i))
+        
+        (retcode, stdout, stderr) = self.gscommand('git-sweep preview --csv')
+        
+        valid_csv = True
+        data = stdout.split('\r\n')
+        for row in data:
+            if row.count(',') != 2 and row.strip() != '':
+                valid_csv = False
+        
+        self.assertTrue(valid_csv)
 
     def test_will_preserve_arguments(self):
         """


### PR DESCRIPTION
Added --csv option to the preview mode. This clears all other output to stdout except information about which branches are able to be deleted. In addition it supplies the date of the last commit and the committer name.

Sample:
  $ ./bin/git-sweep preview --csv
  command-line,2012-03-26,robmadole
  develop,2012-03-26,robmadole
  release-0.1.0,2012-03-21,robmadole
  release-0.1.1,2012-03-28,robmadole

This can then be imported into something like Google Docs where the responsible parties can then ensure their branches are able to be deleted.

I also added a unit test, but because of the changing date and author of the output of each branch, just doing an assertion of exact string matches won't work that well. I've never used Python before, so not being familiar with, well, anything isn't lending itself to me finding an awesome way to test this. Hopefully someone else can provide a better way of being able to unit or, if you think counting commas will suffice for now, even better :)
