### PR TITLE
Develop

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,9 +1,19 @@
 News
 ====
 
+0.1.1
+
+*Release date: March 28, 2012*
+
+* Fix issue #1 which makes the git-sweep help menus more useful
+* Fix a minor grammar issue in the help
+* Fix issue #2 which dropped extra options when telling you to use
+  cleanup
+* Added a --force option to skip confirmation prompt
+
 0.1.0
 -----
 
-*Release date: 0.1.0*
+*Release date: n/a*
 
 * Initial release

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -54,9 +54,10 @@ try:
 except ImportError:
     ez = {}
     if USE_DISTRIBUTE:
-        exec urllib2.urlopen('http://python-distribute.org/distribute_setup.py'
-                         ).read() in ez
-        ez['use_setuptools'](to_dir=tmpeggs, download_delay=0, no_fake=True)
+        ez = {}
+        #exec urllib2.urlopen('http://python-distribute.org/distribute_setup.py'
+        #                 ).read() in ez
+        #ez['use_setuptools'](to_dir=tmpeggs, download_delay=0, no_fake=True)
     else:
         exec urllib2.urlopen('http://peak.telecommunity.com/dist/ez_setup.py'
                              ).read() in ez

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
-version = '0.1.0'
+version = '0.1.1'
 
 install_requires = [
     'GitPython>=0.3.2RC1']

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,17 @@ setup(name='git-sweep',
     description="Clean up branches from your Git remotes",
     long_description=README + '\n\n' + NEWS,
     classifiers=[
-      # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'License :: OSI Approved :: MIT License',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Operating System :: POSIX',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Software Development :: Quality Assurance',
+        'Topic :: Software Development :: Version Control',
+        'Topic :: Text Processing'
     ],
     keywords='git maintenance branches',
     author='Arc90, Inc.',

--- a/src/gitsweep/cli.py
+++ b/src/gitsweep/cli.py
@@ -17,7 +17,7 @@ class CommandLine(object):
     """
     parser = ArgumentParser(
         description='Clean up your Git remote branches.',
-        usage='git-sweep <action> [-h]',
+        usage='git-sweep <action> [-h] --origin [remote name] --master [branch name]',
         )
 
     _sub_parsers = parser.add_subparsers(title='action',

--- a/src/gitsweep/tests/test_cli.py
+++ b/src/gitsweep/tests/test_cli.py
@@ -16,7 +16,7 @@ class TestHelpMenu(CommandTestCase):
         (retcode, stdout, stderr) = self.gscommand('git-sweep -h')
 
         self.assertResults('''
-            usage: git-sweep <action> [-h]
+            usage: git-sweep <action> [-h] --origin [remote name]  --master [branch name]
 
             Clean up your Git remote branches.
 

--- a/src/gitsweep/tests/test_cli.py
+++ b/src/gitsweep/tests/test_cli.py
@@ -22,6 +22,8 @@ class TestHelpMenu(CommandTestCase):
 
             optional arguments:
               -h, --help         show this help message and exit
+              --origin [remote name]  select a specific remote (default is 'origin')
+              --master [branch name]  select a specific branch to use as master (default is 'master')
 
             action:
               Preview changes or perform clean up

--- a/src/gitsweep/tests/test_cli.py
+++ b/src/gitsweep/tests/test_cli.py
@@ -22,8 +22,6 @@ class TestHelpMenu(CommandTestCase):
 
             optional arguments:
               -h, --help         show this help message and exit
-              --origin [remote name]  select a specific remote (default is 'origin')
-              --master [branch name]  select a specific branch to use as master (default is 'master')
 
             action:
               Preview changes or perform clean up


### PR DESCRIPTION
Fix for issue Only interacts with origin remote. Needs a feature to clean up all remotes. #34
All I did was add a mention of the --master and --origin commands in the main help of the utility.  When I first used it, there was a lack of clarity as to how to use it and since I named my remote github, I had no access to the help in the cleanup and preview options.  They would just throw me an "origin cannot be found" error instead of explaining why.  