### PR TITLE
git-sweep cleanup doesn't clean the rest of the branches if you don't have permissions to delete one branch

### DIFF
--- a/src/gitsweep/cli.py
+++ b/src/gitsweep/cli.py
@@ -147,8 +147,11 @@ class CommandLine(object):
                 sys.stdout.write('\n')
                 for ref in ok_to_delete:
                     sys.stdout.write('  deleting {0}'.format(ref.remote_head))
-                    deleter.remove_remote_refs([ref])
-                    sys.stdout.write(' (done)\n')
+                    _, errors = deleter.remove_remote_refs([ref])
+                    if errors:
+                        sys.stdout.write(' (failed)\n')
+                    else:
+                        sys.stdout.write(' (done)\n')
 
                 sys.stdout.write('\nAll done!\n')
                 sys.stdout.write('\nTell everyone to run `git fetch --prune` '

--- a/src/gitsweep/deleter.py
+++ b/src/gitsweep/deleter.py
@@ -1,3 +1,7 @@
+from collections import namedtuple
+
+from git import GitCommandError
+
 from .base import BaseOperation
 
 
@@ -16,7 +20,12 @@ class Deleter(BaseOperation):
         origin = self._origin
 
         pushes = []
+        errors = []
         for ref in refs:
-            pushes.append(origin.push(':{0}'.format(ref.remote_head)))
+            try:
+                pushes.append(origin.push(':{0}'.format(ref.remote_head)))
+            except GitCommandError:
+                errors.append(ref.remote_head)
 
-        return pushes
+        RemoveResults = namedtuple('RemoveResults', 'pushes errors')
+        return RemoveResults(pushes, errors)

--- a/src/gitsweep/tests/test_deleter.py
+++ b/src/gitsweep/tests/test_deleter.py
@@ -34,7 +34,7 @@ class TestDeleter(GitSweepTestCase, InspectorTestCase, DeleterTestCase):
         self.assertEqual(7, len(before))
 
         # Delete from the remote through the clone
-        pushes = self.deleter.remove_remote_refs(
+        pushes, _ = self.deleter.remove_remote_refs(
             self.merged_refs(refobjs=True))
 
         # Make sure it removed the expected number
@@ -66,7 +66,7 @@ class TestDeleter(GitSweepTestCase, InspectorTestCase, DeleterTestCase):
         self.assertEqual(6, len(before))
 
         # Delete through the clone which pushes to this remote
-        pushes = self.deleter.remove_remote_refs(
+        pushes, _ = self.deleter.remove_remote_refs(
             self.merged_refs(refobjs=True))
 
         # Make sure it removed the expected number


### PR DESCRIPTION
**Problem**: When trying to clean up branches (`git-sweep cleanup`), the process stops in the middle e.g. if there is one branch which you are not allowed to delete.

**Solution**: Catch the exception and continue deleting the rest of the branches.